### PR TITLE
fix error brought from wrong python-magic deps

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -44,7 +44,7 @@ cd binwalk
 sudo ./deps.sh --yes
 reset
 sudo python3 ./setup.py install
-sudo pip3 install git+https://github.com/ahupp/python-magic
+sudo pip3 install python-magic
 sudo pip3 install git+https://github.com/sviehb/jefferson
 cd ..
 


### PR DESCRIPTION
The python-magic==0.4.28 has a bug that has been disscussed in https://github.com/ahupp/python-magic/issues/313, which could cause this error: 

> root@65cd61496027:/workspaces/firmafl-repro# python3 -c "import magic"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/local/lib/python3.5/dist-packages/magic/__init__.py", line 234, in <module>
    libmagic = loader.load_lib()
  File "/usr/local/lib/python3.5/dist-packages/magic/loader.py", line 77, in load_lib
    raise ImportError("python-magic: failed to find libmagic.  Check your installation")
ImportError: python-magic: failed to find libmagic.  Check your installation

We can just install python-magic from pypi whose version is 0.4.27, which is good.